### PR TITLE
feat(types): add types submodule for Compound Engineering Triangle

### DIFF
--- a/src/agent_workshop/agents/software_dev/types/__init__.py
+++ b/src/agent_workshop/agents/software_dev/types/__init__.py
@@ -1,0 +1,56 @@
+"""Types submodule for Compound Engineering Triangle workflows.
+
+This module provides shared type definitions used across the triangle:
+- IssueToPR → PRPipeline → PRCommentProcessor
+
+Types are organized into three categories:
+1. State types (TypedDict for LangGraph compatibility)
+2. Metrics types (dataclasses and Pydantic for observability)
+3. GitHub types (Pydantic models for external integration)
+
+Usage:
+    from agent_workshop.agents.software_dev.types import (
+        TriangleState,
+        IssueSpecification,
+        CompoundMetrics,
+    )
+"""
+
+from agent_workshop.agents.software_dev.types.github import (
+    CommentFix,
+    CreatedIssue,
+    FeedbackSummary,
+    PRInfo,
+    ReviewComment,
+)
+from agent_workshop.agents.software_dev.types.metrics import (
+    CommentProcessorQuality,
+    CompoundMetrics,
+    NodeExecution,
+    PRReviewQuality,
+    WorkflowExecution,
+)
+from agent_workshop.agents.software_dev.types.state import (
+    IssueSpecification,
+    TriangleState,
+    VerificationResult,
+)
+
+__all__ = [
+    # State types (LangGraph compatible)
+    "TriangleState",
+    "IssueSpecification",
+    "VerificationResult",
+    # Metrics types (operational, quality, compound)
+    "NodeExecution",
+    "WorkflowExecution",
+    "PRReviewQuality",
+    "CommentProcessorQuality",
+    "CompoundMetrics",
+    # GitHub types (external integration)
+    "CreatedIssue",
+    "PRInfo",
+    "ReviewComment",
+    "CommentFix",
+    "FeedbackSummary",
+]

--- a/src/agent_workshop/agents/software_dev/types/github.py
+++ b/src/agent_workshop/agents/software_dev/types/github.py
@@ -1,0 +1,213 @@
+"""GitHub-related type definitions for Compound Engineering workflows.
+
+Types for tracking issues, PRs, comments, and human feedback.
+"""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class CreatedIssue(BaseModel):
+    """Record of a created GitHub issue.
+
+    Output from PlanToIssues workflow.
+    """
+
+    task_title: str = Field(description="Issue title")
+    issue_number: int = Field(description="GitHub issue number")
+    issue_url: str = Field(description="Full URL to the issue")
+    branch_name: str = Field(description="Target branch from metadata")
+    complexity: str = Field(
+        default="medium",
+        description="Estimated complexity",
+    )
+    priority: str = Field(
+        default="medium",
+        description="Issue priority",
+    )
+    epic_id: str | None = Field(
+        default=None,
+        description="Parent epic identifier",
+    )
+    depends_on: list[int] = Field(
+        default_factory=list,
+        description="Issue numbers this depends on",
+    )
+    created_at: datetime = Field(
+        default_factory=datetime.now,
+        description="When the issue was created",
+    )
+
+
+class PRInfo(BaseModel):
+    """Pull request metadata.
+
+    Tracks PR state through the triangle workflow.
+    """
+
+    pr_number: int = Field(description="GitHub PR number")
+    pr_url: str = Field(description="Full URL to the PR")
+    title: str = Field(description="PR title")
+    branch_name: str = Field(description="Source branch")
+    base_branch: str = Field(
+        default="main",
+        description="Target branch for merge",
+    )
+    state: Literal["open", "closed", "merged", "draft"] = Field(
+        default="draft",
+        description="PR state",
+    )
+    issue_number: int | None = Field(
+        default=None,
+        description="Linked issue number",
+    )
+    created_at: datetime = Field(
+        default_factory=datetime.now,
+        description="When the PR was created",
+    )
+    files_changed: int = Field(
+        default=0,
+        description="Number of files changed",
+    )
+    additions: int = Field(
+        default=0,
+        description="Lines added",
+    )
+    deletions: int = Field(
+        default=0,
+        description="Lines deleted",
+    )
+
+
+class CommentFix(BaseModel):
+    """Per-comment fix tracking for PRCommentProcessor.
+
+    Records the outcome of attempting to apply a fix for a review comment.
+    """
+
+    comment_id: str = Field(description="GitHub comment ID")
+    file_path: str = Field(description="File the comment references")
+    line_number: int | None = Field(
+        default=None,
+        description="Line number if inline comment",
+    )
+    comment_body: str = Field(description="The review comment text")
+    outcome: Literal["applied", "skipped", "failed"] = Field(
+        description="Fix attempt outcome",
+    )
+    attempts: int = Field(
+        default=1,
+        description="Number of fix attempts",
+    )
+    fix_description: str | None = Field(
+        default=None,
+        description="Description of the fix applied",
+    )
+    tests_passed_after: bool | None = Field(
+        default=None,
+        description="Whether tests passed after fix",
+    )
+    human_approved: bool | None = Field(
+        default=None,
+        description="Human approval status (from reactions)",
+    )
+    error_message: str | None = Field(
+        default=None,
+        description="Error message if failed",
+    )
+
+
+class ReviewComment(BaseModel):
+    """A PR review comment to be processed.
+
+    Input to PRCommentProcessor workflow.
+    """
+
+    comment_id: str = Field(description="GitHub comment ID")
+    author: str = Field(description="Comment author username")
+    body: str = Field(description="Comment text")
+    file_path: str | None = Field(
+        default=None,
+        description="File path for inline comments",
+    )
+    line_number: int | None = Field(
+        default=None,
+        description="Line number for inline comments",
+    )
+    is_resolved: bool = Field(
+        default=False,
+        description="Whether comment is marked resolved",
+    )
+    created_at: datetime = Field(
+        default_factory=datetime.now,
+        description="When comment was created",
+    )
+    source_type: Literal["greptile", "human", "bot"] = Field(
+        default="human",
+        description="Source of the comment",
+    )
+
+
+class FeedbackSummary(BaseModel):
+    """Aggregated human feedback from GitHub reactions.
+
+    Used to calculate review quality metrics.
+    """
+
+    # Review feedback
+    true_positives: int = Field(
+        default=0,
+        description="Issues confirmed valid (thumbs up on review)",
+    )
+    false_positives: int = Field(
+        default=0,
+        description="Issues marked incorrect (thumbs down on review)",
+    )
+
+    # Fix feedback
+    fixes_approved: int = Field(
+        default=0,
+        description="Fixes accepted (rocket reaction)",
+    )
+    fixes_rejected: int = Field(
+        default=0,
+        description="Fixes rejected (thumbs down on fix)",
+    )
+
+    # Comment resolution
+    comments_resolved: int = Field(
+        default=0,
+        description="Comments marked as resolved",
+    )
+    comments_unresolved: int = Field(
+        default=0,
+        description="Comments still open",
+    )
+
+    @property
+    def total_review_feedback(self) -> int:
+        """Total review reactions received."""
+        return self.true_positives + self.false_positives
+
+    @property
+    def total_fix_feedback(self) -> int:
+        """Total fix reactions received."""
+        return self.fixes_approved + self.fixes_rejected
+
+    @property
+    def review_accuracy(self) -> float:
+        """Percentage of reviews marked as valid."""
+        total = self.total_review_feedback
+        if total == 0:
+            return 1.0
+        return self.true_positives / total
+
+    @property
+    def fix_acceptance_rate(self) -> float:
+        """Percentage of fixes accepted."""
+        total = self.total_fix_feedback
+        if total == 0:
+            return 1.0
+        return self.fixes_approved / total

--- a/src/agent_workshop/agents/software_dev/types/metrics.py
+++ b/src/agent_workshop/agents/software_dev/types/metrics.py
@@ -1,0 +1,297 @@
+"""Metrics type definitions for Compound Engineering observability.
+
+Three layers of metrics:
+1. Operational: Duration, tokens, cost per node/workflow
+2. Quality: Precision, recall, F1 for PR reviews; pass rates for verification
+3. Compound: V × FQ × IF score combining all dimensions
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field, computed_field
+
+
+@dataclass
+class NodeExecution:
+    """Per-node operational metrics.
+
+    Captures LLM usage and timing for a single workflow node.
+    """
+
+    node_name: str
+    started_at: datetime
+    ended_at: datetime | None = None
+    llm_calls: int = 0
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    cost_usd: float = 0.0
+    status: Literal["pending", "running", "success", "failure", "skipped"] = "pending"
+    error_message: str | None = None
+
+    @property
+    def duration_seconds(self) -> float | None:
+        """Calculate duration if ended."""
+        if self.ended_at and self.started_at:
+            return (self.ended_at - self.started_at).total_seconds()
+        return None
+
+    @property
+    def total_tokens(self) -> int:
+        """Total tokens used in this node."""
+        return self.prompt_tokens + self.completion_tokens
+
+
+@dataclass
+class WorkflowExecution:
+    """Per-workflow operational metrics.
+
+    Aggregates node executions for a complete workflow run.
+    """
+
+    workflow_name: str
+    run_id: str
+    thread_id: str
+    started_at: datetime
+    ended_at: datetime | None = None
+    node_executions: list[NodeExecution] = field(default_factory=list)
+    status: Literal["pending", "running", "success", "failure", "partial"] = "pending"
+    error_message: str | None = None
+
+    @property
+    def duration_seconds(self) -> float | None:
+        """Calculate total workflow duration."""
+        if self.ended_at and self.started_at:
+            return (self.ended_at - self.started_at).total_seconds()
+        return None
+
+    @property
+    def total_llm_calls(self) -> int:
+        """Sum of LLM calls across all nodes."""
+        return sum(n.llm_calls for n in self.node_executions)
+
+    @property
+    def total_tokens(self) -> int:
+        """Sum of tokens across all nodes."""
+        return sum(n.total_tokens for n in self.node_executions)
+
+    @property
+    def total_cost_usd(self) -> float:
+        """Sum of costs across all nodes."""
+        return sum(n.cost_usd for n in self.node_executions)
+
+
+class PRReviewQuality(BaseModel):
+    """Quality metrics for PR review feedback.
+
+    Tracks true/false positives to calculate precision and recall.
+    """
+
+    # Issue counts by severity
+    security_issues: dict[str, int] = Field(
+        default_factory=dict,
+        description="Security issues by severity (critical, high, medium, low)",
+    )
+    quality_issues: dict[str, int] = Field(
+        default_factory=dict,
+        description="Quality issues by category",
+    )
+
+    # Review outcome
+    recommendation: Literal["approve", "request_changes", "comment"] = Field(
+        description="Final review recommendation",
+    )
+    blocking_issues: int = Field(
+        default=0,
+        description="Number of issues blocking approval",
+    )
+
+    # Feedback accuracy (populated from human reactions)
+    true_positives: int = Field(
+        default=0,
+        description="Issues confirmed as valid by human feedback",
+    )
+    false_positives: int = Field(
+        default=0,
+        description="Issues marked as incorrect by human feedback",
+    )
+    total_issues_raised: int = Field(
+        default=0,
+        description="Total number of issues raised in review",
+    )
+
+    @computed_field
+    @property
+    def precision(self) -> float:
+        """Precision = TP / (TP + FP). How many raised issues were valid."""
+        total = self.true_positives + self.false_positives
+        if total == 0:
+            return 1.0  # No issues means perfect precision
+        return self.true_positives / total
+
+
+class CommentProcessorQuality(BaseModel):
+    """Quality metrics for comment processing iteration.
+
+    Tracks fix application success rate.
+    """
+
+    total_comments: int = Field(
+        default=0,
+        description="Total comments processed",
+    )
+    applied: int = Field(
+        default=0,
+        description="Fixes successfully applied",
+    )
+    skipped: int = Field(
+        default=0,
+        description="Comments skipped (not auto-fixable)",
+    )
+    failed: int = Field(
+        default=0,
+        description="Fix attempts that failed",
+    )
+    fixes: list[dict] = Field(
+        default_factory=list,
+        description="Detailed fix records",
+    )
+
+    @computed_field
+    @property
+    def application_rate(self) -> float:
+        """Percentage of comments that resulted in applied fixes."""
+        if self.total_comments == 0:
+            return 1.0
+        return self.applied / self.total_comments
+
+    @computed_field
+    @property
+    def success_rate(self) -> float:
+        """Percentage of attempted fixes that succeeded."""
+        attempted = self.applied + self.failed
+        if attempted == 0:
+            return 1.0
+        return self.applied / attempted
+
+
+@dataclass
+class CompoundMetrics:
+    """V × FQ × IF compound engineering score.
+
+    Combines three dimensions into a single productivity metric:
+    - V (Velocity): Speed and self-verification success
+    - FQ (Feedback Quality): Precision and usefulness of reviews
+    - IF (Iteration Frequency): Fix application and autonomy
+    """
+
+    # Velocity components (V)
+    lines_changed: int = 0
+    duration_seconds: float = 0.0
+    self_verification_attempts: int = 0
+    self_verification_passes: int = 0
+
+    # Feedback Quality components (FQ)
+    review_true_positives: int = 0
+    review_false_positives: int = 0
+    review_total_issues: int = 0
+
+    # Iteration Frequency components (IF)
+    total_fixes_attempted: int = 0
+    fixes_applied_first_try: int = 0
+    human_interventions: int = 0
+    total_iterations: int = 0
+
+    @property
+    def lines_per_second(self) -> float:
+        """Code velocity: lines changed per second."""
+        if self.duration_seconds == 0:
+            return 0.0
+        return self.lines_changed / self.duration_seconds
+
+    @property
+    def self_verification_pass_rate(self) -> float:
+        """Percentage of verification attempts that passed."""
+        if self.self_verification_attempts == 0:
+            return 1.0
+        return self.self_verification_passes / self.self_verification_attempts
+
+    @property
+    def velocity_score(self) -> float:
+        """V score: weighted combination of speed and verification success."""
+        # Normalize lines/second (assume 10 l/s is excellent = 100)
+        speed_component = min(self.lines_per_second * 10, 100)
+        verification_component = self.self_verification_pass_rate * 100
+        # Weight: 40% speed, 60% verification quality
+        return (speed_component * 0.4) + (verification_component * 0.6)
+
+    @property
+    def review_precision(self) -> float:
+        """Precision of review feedback."""
+        total = self.review_true_positives + self.review_false_positives
+        if total == 0:
+            return 1.0
+        return self.review_true_positives / total
+
+    @property
+    def review_recall(self) -> float:
+        """Recall - currently estimated as TP / total issues raised."""
+        if self.review_total_issues == 0:
+            return 1.0
+        return min(self.review_true_positives / self.review_total_issues, 1.0)
+
+    @property
+    def review_f1(self) -> float:
+        """F1 score combining precision and recall."""
+        p, r = self.review_precision, self.review_recall
+        if p + r == 0:
+            return 0.0
+        return 2 * (p * r) / (p + r)
+
+    @property
+    def feedback_quality_score(self) -> float:
+        """FQ score: F1 score scaled to 0-100."""
+        return self.review_f1 * 100
+
+    @property
+    def fix_application_rate(self) -> float:
+        """Percentage of fixes applied on first attempt."""
+        if self.total_fixes_attempted == 0:
+            return 1.0
+        return self.fixes_applied_first_try / self.total_fixes_attempted
+
+    @property
+    def autonomy_rate(self) -> float:
+        """Percentage of iterations without human intervention."""
+        if self.total_iterations == 0:
+            return 1.0
+        autonomous = self.total_iterations - self.human_interventions
+        return autonomous / self.total_iterations
+
+    @property
+    def iteration_frequency_score(self) -> float:
+        """IF score: weighted combination of fix rate and autonomy."""
+        # Weight: 50% fix application, 50% autonomy
+        fix_component = self.fix_application_rate * 100
+        autonomy_component = self.autonomy_rate * 100
+        return (fix_component * 0.5) + (autonomy_component * 0.5)
+
+    @property
+    def compound_score(self) -> float:
+        """Final V × FQ × IF compound score.
+
+        Uses geometric mean to normalize across dimensions.
+        Result is 0-100 scale.
+        """
+        v = self.velocity_score / 100
+        fq = self.feedback_quality_score / 100
+        if_score = self.iteration_frequency_score / 100
+
+        # Avoid zero in geometric mean
+        v = max(v, 0.01)
+        fq = max(fq, 0.01)
+        if_score = max(if_score, 0.01)
+
+        # Geometric mean normalized to 100
+        return ((v * fq * if_score) ** (1 / 3)) * 100

--- a/src/agent_workshop/agents/software_dev/types/state.py
+++ b/src/agent_workshop/agents/software_dev/types/state.py
@@ -1,0 +1,111 @@
+"""State type definitions for Compound Engineering Triangle workflows.
+
+This module defines TypedDict-based state types required for LangGraph compatibility.
+TypedDict is used instead of Pydantic to ensure proper state checkpointing and restoration.
+"""
+
+from typing import Any, TypedDict
+
+from pydantic import BaseModel, Field
+
+
+class TriangleState(TypedDict, total=False):
+    """Unified state for Triangle Orchestrator workflow.
+
+    This state flows through the IssueToPR → PRPipeline → PRCommentProcessor triangle.
+    Uses total=False to allow optional fields during partial state updates.
+    """
+
+    # Issue context
+    issue_number: int
+    repo_name: str
+    branch_name: str
+    working_dir: str
+
+    # Workflow results (populated as triangle progresses)
+    issue_to_pr_result: dict[str, Any] | None
+    pr_pipeline_result: dict[str, Any] | None
+    comment_processor_result: dict[str, Any] | None
+
+    # PR metadata (populated after IssueToPR completes)
+    pr_number: int | None
+    pr_url: str | None
+
+    # Flow control
+    current_step: str
+    approved_steps: list[str]
+    requires_human_approval: bool
+
+    # Metrics collection
+    metrics: dict[str, Any]
+
+    # Error handling
+    error: str | None
+    retry_count: int
+
+
+class IssueSpecification(BaseModel):
+    """Parsed GitHub issue specification.
+
+    Extracted from issue body with structured sections for implementation.
+    """
+
+    title: str = Field(description="Issue title")
+    body: str = Field(description="Raw issue body markdown")
+    requirements: list[str] = Field(
+        default_factory=list,
+        description="Extracted requirements from issue body",
+    )
+    acceptance_criteria: list[str] = Field(
+        default_factory=list,
+        description="Extracted acceptance criteria",
+    )
+    files_to_create: list[str] = Field(
+        default_factory=list,
+        description="Files to be created",
+    )
+    files_to_modify: list[str] = Field(
+        default_factory=list,
+        description="Files to be modified",
+    )
+    branch_name: str = Field(description="Target branch name from metadata")
+    complexity: str = Field(
+        default="medium",
+        description="Estimated complexity: simple, medium, complex",
+    )
+    depends_on: list[str] = Field(
+        default_factory=list,
+        description="Issue dependencies (e.g., ['#3', '#5'])",
+    )
+
+
+class VerificationResult(TypedDict, total=False):
+    """Tiered verification output from self-verification node.
+
+    Each tier is evaluated in order: SCHEMA → SYNTAX → LINT → TYPE → TEST.
+    Verification stops at first failure tier.
+    """
+
+    # Overall result
+    level: str  # "schema", "syntax", "lint", "type", "test"
+    passed: bool
+    highest_passing_level: str | None
+
+    # Per-tier results
+    schema_valid: bool | None
+    syntax_valid: bool | None
+    lint_valid: bool | None
+    types_valid: bool | None
+    tests_pass: bool | None
+
+    # Error details
+    errors: list[str]
+    warnings: list[str]
+
+    # Tier-specific output
+    lint_output: str | None
+    type_output: str | None
+    test_output: str | None
+
+    # Timing
+    duration_seconds: float


### PR DESCRIPTION
## Summary

Implements shared type definitions for the Compound Engineering Triangle workflows (#3):

- **State types** (TypedDict for LangGraph compatibility):
  - `TriangleState` - Unified workflow state for IssueToPR → PRPipeline → PRCommentProcessor
  - `IssueSpecification` - Parsed GitHub issue with structured requirements
  - `VerificationResult` - Tiered verification output (SCHEMA → LINT → TYPE → TEST)

- **Metrics types** (3-layer observability):
  - `NodeExecution` / `WorkflowExecution` - Operational metrics (tokens, cost, duration)
  - `PRReviewQuality` / `CommentProcessorQuality` - Quality metrics with precision tracking
  - `CompoundMetrics` - V × FQ × IF scoring with geometric mean calculation

- **GitHub types** (Pydantic models):
  - `CreatedIssue` / `PRInfo` - Issue and PR metadata tracking
  - `ReviewComment` / `CommentFix` - Comment processing input/output
  - `FeedbackSummary` - Human feedback aggregation from reactions

## Test Plan

- [x] All types importable via `from agent_workshop.agents.software_dev.types import ...`
- [x] Ruff linting passes
- [x] Python import verification succeeds
- [ ] PRPipeline review (dog-fooding)

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)