### PR TITLE
feat(persistence): add SqliteSaver wrapper for triangle workflows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "jinja2>=3.1.6",
     "claude-code-sdk>=0.0.25",
+    "langgraph-checkpoint-sqlite>=3.0.1",
 ]
 
 [project.urls]

--- a/src/agent_workshop/utils/persistence.py
+++ b/src/agent_workshop/utils/persistence.py
@@ -1,0 +1,384 @@
+"""Persistence layer for human-gated triangle workflows.
+
+Wraps LangGraph's SqliteSaver for workflow state persistence, enabling
+workflows to survive process restarts between human approval checkpoints.
+
+Usage:
+    from agent_workshop.utils.persistence import (
+        get_checkpointer,
+        TrianglePersistence,
+    )
+
+    # Get checkpointer for graph compilation
+    checkpointer = get_checkpointer()
+    graph = workflow.compile(checkpointer=checkpointer)
+
+    # Query workflow states
+    persistence = TrianglePersistence()
+    pending = persistence.list_pending_approvals()
+    state = persistence.get_thread_state("issue-42")
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from langgraph.checkpoint.sqlite import SqliteSaver
+
+if TYPE_CHECKING:
+    from langgraph.checkpoint.base import CheckpointTuple
+
+# Default state directory relative to working directory
+DEFAULT_STATE_DIR = ".triangle"
+DEFAULT_DB_NAME = "state.db"
+
+
+def get_state_dir(base_dir: str | Path | None = None) -> Path:
+    """Get or create the state directory.
+
+    Args:
+        base_dir: Base directory for state storage. Defaults to current directory.
+
+    Returns:
+        Path to the state directory (created if missing).
+    """
+    if base_dir is None:
+        base_dir = Path.cwd()
+    else:
+        base_dir = Path(base_dir)
+
+    state_dir = base_dir / DEFAULT_STATE_DIR
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return state_dir
+
+
+def get_db_path(base_dir: str | Path | None = None) -> Path:
+    """Get the path to the state database.
+
+    Args:
+        base_dir: Base directory for state storage.
+
+    Returns:
+        Path to the SQLite database file.
+    """
+    return get_state_dir(base_dir) / DEFAULT_DB_NAME
+
+
+def get_checkpointer(
+    db_path: str | Path | None = None,
+    base_dir: str | Path | None = None,
+) -> SqliteSaver:
+    """Factory function returning SqliteSaver configured for triangle workflows.
+
+    Args:
+        db_path: Explicit path to database file. If None, uses default location.
+        base_dir: Base directory for state storage (ignored if db_path provided).
+
+    Returns:
+        Configured SqliteSaver instance.
+
+    Example:
+        checkpointer = get_checkpointer()
+        graph = workflow.compile(checkpointer=checkpointer)
+    """
+    if db_path is None:
+        db_path = get_db_path(base_dir)
+    else:
+        db_path = Path(db_path)
+        # Ensure parent directory exists
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    return SqliteSaver.from_conn_string(str(db_path))
+
+
+def make_thread_id(issue_number: int | None = None, epic_id: str | None = None) -> str:
+    """Generate a thread ID following triangle conventions.
+
+    Args:
+        issue_number: GitHub issue number for issue-level workflows.
+        epic_id: Epic identifier for epic-level orchestration.
+
+    Returns:
+        Thread ID string in format "issue-{number}" or "epic-{id}".
+
+    Raises:
+        ValueError: If neither issue_number nor epic_id is provided.
+    """
+    if issue_number is not None:
+        return f"issue-{issue_number}"
+    elif epic_id is not None:
+        return f"epic-{epic_id}"
+    else:
+        raise ValueError("Either issue_number or epic_id must be provided")
+
+
+def parse_thread_id(thread_id: str) -> dict[str, Any]:
+    """Parse a thread ID into its components.
+
+    Args:
+        thread_id: Thread ID string.
+
+    Returns:
+        Dict with 'type' ('issue' or 'epic') and 'id' (number or string).
+    """
+    if thread_id.startswith("issue-"):
+        return {"type": "issue", "id": int(thread_id[6:])}
+    elif thread_id.startswith("epic-"):
+        return {"type": "epic", "id": thread_id[5:]}
+    else:
+        return {"type": "unknown", "id": thread_id}
+
+
+@dataclass
+class PendingApproval:
+    """Represents a workflow waiting for human approval."""
+
+    thread_id: str
+    current_step: str
+    issue_number: int | None
+    epic_id: str | None
+    created_at: datetime | None
+    last_updated: datetime | None
+    state_values: dict[str, Any]
+
+    @property
+    def display_name(self) -> str:
+        """Human-readable name for display."""
+        parsed = parse_thread_id(self.thread_id)
+        if parsed["type"] == "issue":
+            return f"Issue #{parsed['id']}"
+        elif parsed["type"] == "epic":
+            return f"Epic: {parsed['id']}"
+        return self.thread_id
+
+
+class TrianglePersistence:
+    """State management wrapper for triangle workflows.
+
+    Provides high-level query methods for CLI and orchestration:
+    - Get current state for a thread
+    - List all workflows waiting for human approval
+    - Get execution history for a thread
+
+    Example:
+        persistence = TrianglePersistence()
+
+        # List pending approvals for CLI display
+        pending = persistence.list_pending_approvals()
+        for p in pending:
+            print(f"{p.display_name}: waiting at {p.current_step}")
+
+        # Get specific thread state
+        state = persistence.get_thread_state("issue-42")
+        if state:
+            print(f"Current step: {state['current_step']}")
+    """
+
+    def __init__(
+        self,
+        db_path: str | Path | None = None,
+        base_dir: str | Path | None = None,
+    ):
+        """Initialize persistence wrapper.
+
+        Args:
+            db_path: Explicit path to database file.
+            base_dir: Base directory for state storage.
+        """
+        if db_path is None:
+            self.db_path = get_db_path(base_dir)
+        else:
+            self.db_path = Path(db_path)
+
+    def _get_connection(self) -> sqlite3.Connection:
+        """Get a database connection."""
+        return sqlite3.connect(str(self.db_path))
+
+    def _get_checkpointer(self) -> SqliteSaver:
+        """Get a checkpointer instance."""
+        return SqliteSaver.from_conn_string(str(self.db_path))
+
+    def get_thread_state(self, thread_id: str) -> dict[str, Any] | None:
+        """Get current state for a thread.
+
+        Args:
+            thread_id: Thread ID (e.g., "issue-42", "epic-v1").
+
+        Returns:
+            Current state values dict, or None if thread not found.
+        """
+        config = {"configurable": {"thread_id": thread_id}}
+
+        with self._get_checkpointer() as checkpointer:
+            checkpoint_tuple = checkpointer.get_tuple(config)
+            if checkpoint_tuple is None:
+                return None
+
+            checkpoint = checkpoint_tuple.checkpoint
+            return checkpoint.get("channel_values", {})
+
+    def get_thread_config(
+        self,
+        thread_id: str,
+        checkpoint_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Get config dict for invoking a graph with this thread.
+
+        Args:
+            thread_id: Thread ID.
+            checkpoint_id: Optional specific checkpoint to resume from.
+
+        Returns:
+            Config dict for graph.invoke().
+        """
+        config: dict[str, Any] = {
+            "configurable": {"thread_id": thread_id}
+        }
+        if checkpoint_id:
+            config["configurable"]["checkpoint_id"] = checkpoint_id
+        return config
+
+    def list_pending_approvals(self) -> list[PendingApproval]:
+        """List all workflows waiting for human approval.
+
+        Scans all threads and returns those with requires_human_approval=True
+        or that are at an interrupt point.
+
+        Returns:
+            List of PendingApproval objects.
+        """
+        pending: list[PendingApproval] = []
+
+        if not self.db_path.exists():
+            return pending
+
+        # Query distinct thread IDs from checkpoints table
+        conn = self._get_connection()
+        try:
+            cursor = conn.cursor()
+            # SqliteSaver stores checkpoints in a table with thread_id
+            cursor.execute("""
+                SELECT DISTINCT thread_id
+                FROM checkpoints
+                ORDER BY thread_id
+            """)
+            thread_ids = [row[0] for row in cursor.fetchall()]
+        except sqlite3.OperationalError:
+            # Table doesn't exist yet
+            return pending
+        finally:
+            conn.close()
+
+        # Check each thread for pending approval status
+        with self._get_checkpointer() as checkpointer:
+            for thread_id in thread_ids:
+                config = {"configurable": {"thread_id": thread_id}}
+                checkpoint_tuple = checkpointer.get_tuple(config)
+
+                if checkpoint_tuple is None:
+                    continue
+
+                state = checkpoint_tuple.checkpoint.get("channel_values", {})
+
+                # Check if workflow is waiting for approval
+                requires_approval = state.get("requires_human_approval", False)
+                current_step = state.get("current_step", "unknown")
+
+                # Also check if there's a pending_sends (interrupt indicator)
+                has_pending = bool(
+                    checkpoint_tuple.checkpoint.get("pending_sends", [])
+                )
+
+                if requires_approval or has_pending:
+                    parsed = parse_thread_id(thread_id)
+                    pending.append(
+                        PendingApproval(
+                            thread_id=thread_id,
+                            current_step=current_step,
+                            issue_number=(
+                                parsed["id"] if parsed["type"] == "issue" else None
+                            ),
+                            epic_id=(
+                                parsed["id"] if parsed["type"] == "epic" else None
+                            ),
+                            created_at=None,  # Could parse from checkpoint metadata
+                            last_updated=None,
+                            state_values=state,
+                        )
+                    )
+
+        return pending
+
+    def get_workflow_history(
+        self,
+        thread_id: str,
+        limit: int = 10,
+    ) -> list[CheckpointTuple]:
+        """Get execution history for a thread.
+
+        Args:
+            thread_id: Thread ID.
+            limit: Maximum number of checkpoints to return.
+
+        Returns:
+            List of CheckpointTuple objects, most recent first.
+        """
+        config = {"configurable": {"thread_id": thread_id}}
+        history: list[CheckpointTuple] = []
+
+        with self._get_checkpointer() as checkpointer:
+            for i, checkpoint in enumerate(checkpointer.list(config)):
+                if i >= limit:
+                    break
+                history.append(checkpoint)
+
+        return history
+
+    def thread_exists(self, thread_id: str) -> bool:
+        """Check if a thread exists in the database.
+
+        Args:
+            thread_id: Thread ID to check.
+
+        Returns:
+            True if thread has at least one checkpoint.
+        """
+        return self.get_thread_state(thread_id) is not None
+
+    def list_threads(self, thread_type: str | None = None) -> list[str]:
+        """List all thread IDs.
+
+        Args:
+            thread_type: Optional filter ('issue' or 'epic').
+
+        Returns:
+            List of thread ID strings.
+        """
+        if not self.db_path.exists():
+            return []
+
+        conn = self._get_connection()
+        try:
+            cursor = conn.cursor()
+            cursor.execute("""
+                SELECT DISTINCT thread_id
+                FROM checkpoints
+                ORDER BY thread_id
+            """)
+            thread_ids = [row[0] for row in cursor.fetchall()]
+        except sqlite3.OperationalError:
+            return []
+        finally:
+            conn.close()
+
+        if thread_type:
+            thread_ids = [
+                tid for tid in thread_ids
+                if parse_thread_id(tid)["type"] == thread_type
+            ]
+
+        return thread_ids

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "langfuse" },
     { name = "langgraph" },
+    { name = "langgraph-checkpoint-sqlite" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -63,6 +64,7 @@ requires-dist = [
     { name = "langgraph", specifier = ">=0.2.0" },
     { name = "langgraph", marker = "extra == 'agents'", specifier = ">=0.2.0" },
     { name = "langgraph", marker = "extra == 'pipelines'", specifier = ">=0.2.0" },
+    { name = "langgraph-checkpoint-sqlite", specifier = ">=3.0.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.11.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
@@ -82,6 +84,15 @@ dev = [
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.0" },
     { name = "ruff", specifier = ">=0.6.0" },
+]
+
+[[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405 },
 ]
 
 [[package]]
@@ -790,6 +801,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/0f/07/2b1c042fa87d40cf2db5ca27dc4e8dd86f9a0436a10aa4361a8982718ae7/langgraph_checkpoint-3.0.1.tar.gz", hash = "sha256:59222f875f85186a22c494aedc65c4e985a3df27e696e5016ba0b98a5ed2cee0", size = 137785 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/48/e3/616e3a7ff737d98c1bbb5700dd62278914e2a9ded09a79a1fa93cf24ce12/langgraph_checkpoint-3.0.1-py3-none-any.whl", hash = "sha256:9b04a8d0edc0474ce4eaf30c5d731cee38f11ddff50a6177eead95b5c4e4220b", size = 46249 },
+]
+
+[[package]]
+name = "langgraph-checkpoint-sqlite"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiosqlite" },
+    { name = "langgraph-checkpoint" },
+    { name = "sqlite-vec" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/a0/106a0d6c4f02385b11d9cb1dacedae3beee72023448c619702fc62745f22/langgraph_checkpoint_sqlite-3.0.1.tar.gz", hash = "sha256:c6580138e6abfd2ade7ea49186c664d47ef28dc44538674fa47e50a8a5f8af83", size = 110351 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/95/41be362f3eb25d7b4efe5b034efe8b9ce152a37ffe8a3a2fe1595f40272c/langgraph_checkpoint_sqlite-3.0.1-py3-none-any.whl", hash = "sha256:616124676e5827294966997ed853f5d41490cc61f73b3c79359f4ff307728508", size = 33382 },
 ]
 
 [[package]]
@@ -1897,6 +1922,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
+name = "sqlite-vec"
+version = "0.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/ed/aabc328f29ee6814033d008ec43e44f2c595447d9cccd5f2aabe60df2933/sqlite_vec-0.1.6-py3-none-macosx_10_6_x86_64.whl", hash = "sha256:77491bcaa6d496f2acb5cc0d0ff0b8964434f141523c121e313f9a7d8088dee3", size = 164075 },
+    { url = "https://files.pythonhosted.org/packages/a7/57/05604e509a129b22e303758bfa062c19afb020557d5e19b008c64016704e/sqlite_vec-0.1.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fdca35f7ee3243668a055255d4dee4dea7eed5a06da8cad409f89facf4595361", size = 165242 },
+    { url = "https://files.pythonhosted.org/packages/f2/48/dbb2cc4e5bad88c89c7bb296e2d0a8df58aab9edc75853728c361eefc24f/sqlite_vec-0.1.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b0519d9cd96164cd2e08e8eed225197f9cd2f0be82cb04567692a0a4be02da3", size = 103704 },
+    { url = "https://files.pythonhosted.org/packages/80/76/97f33b1a2446f6ae55e59b33869bed4eafaf59b7f4c662c8d9491b6a714a/sqlite_vec-0.1.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux1_x86_64.whl", hash = "sha256:823b0493add80d7fe82ab0fe25df7c0703f4752941aee1c7b2b02cec9656cb24", size = 151556 },
+    { url = "https://files.pythonhosted.org/packages/6a/98/e8bc58b178266eae2fcf4c9c7a8303a8d41164d781b32d71097924a6bebe/sqlite_vec-0.1.6-py3-none-win_amd64.whl", hash = "sha256:c65bcfd90fa2f41f9000052bcb8bb75d38240b2dae49225389eca6c3136d3f0c", size = 281540 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements persistence layer for human-gated triangle workflows (#7):

- **Factory function**: `get_checkpointer()` returns configured `SqliteSaver` at `.triangle/state.db`
- **TrianglePersistence class** for high-level state queries:
  - `get_thread_state()` - Get current workflow state by thread ID
  - `list_pending_approvals()` - Find all workflows awaiting human approval
  - `get_workflow_history()` - Time-travel debugging via checkpoint history
  - `list_threads()` - List all thread IDs with optional type filtering
- **Thread ID conventions**: `issue-{number}` and `epic-{id}` patterns
- **PendingApproval dataclass** for CLI display formatting

### Dependencies Added
- `langgraph-checkpoint-sqlite` (v3.0.1)
- `aiosqlite` (transitive)

## Test Plan

- [x] Thread ID functions verified (make/parse)
- [x] Checkpointer creation verified
- [x] TrianglePersistence queries work on empty database
- [x] Ruff linting passes

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)