### PR TITLE
feat(cli): add triangle CLI for workflow control

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,8 @@ dependencies = [
     "jinja2>=3.1.6",
     "claude-code-sdk>=0.0.25",
     "langgraph-checkpoint-sqlite>=3.0.1",
+    "click>=8.3.1",
+    "rich>=14.2.0",
 ]
 
 [project.urls]
@@ -39,6 +41,9 @@ Homepage = "https://github.com/trentleslie/agent-workshop"
 Documentation = "https://github.com/trentleslie/agent-workshop#readme"
 Repository = "https://github.com/trentleslie/agent-workshop"
 Issues = "https://github.com/trentleslie/agent-workshop/issues"
+
+[project.scripts]
+triangle = "agent_workshop.cli.main:main"
 
 [project.optional-dependencies]
 dev = [

--- a/src/agent_workshop/cli/__init__.py
+++ b/src/agent_workshop/cli/__init__.py
@@ -1,0 +1,12 @@
+"""CLI module for triangle workflow control.
+
+Provides command-line interface for:
+- Starting triangle workflows
+- Approving human checkpoints
+- Checking workflow status
+- Listing pending approvals
+"""
+
+from agent_workshop.cli.main import cli
+
+__all__ = ["cli"]

--- a/src/agent_workshop/cli/main.py
+++ b/src/agent_workshop/cli/main.py
@@ -1,0 +1,46 @@
+"""Main CLI entry point for triangle workflow control.
+
+Usage:
+    triangle --help
+    triangle start --issue 42 --repo owner/repo
+    triangle status
+    triangle approve issue-42 --step pr_review
+"""
+
+import click
+
+from agent_workshop.cli.triangle import approve, cancel, list_workflows, start, status
+
+
+@click.group()
+@click.version_option(package_name="agent-workshop")
+def cli() -> None:
+    """Triangle workflow control for human-gated automation.
+
+    The triangle workflow automates software development tasks with
+    human approval checkpoints at key decision points.
+
+    Commands:
+        start    - Start a new triangle workflow for an issue
+        status   - Show workflow status (all or specific)
+        approve  - Approve a human checkpoint to resume workflow
+        list     - List all active/pending workflows
+        cancel   - Cancel a running workflow
+    """
+
+
+# Register commands directly (not as subgroup)
+cli.add_command(start)
+cli.add_command(status)
+cli.add_command(approve)
+cli.add_command(list_workflows, name="list")
+cli.add_command(cancel)
+
+
+def main() -> None:
+    """Entry point for the CLI."""
+    cli()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agent_workshop/cli/triangle.py
+++ b/src/agent_workshop/cli/triangle.py
@@ -1,0 +1,333 @@
+"""Triangle workflow commands for CLI.
+
+Commands for controlling human-gated triangle workflows:
+- start: Start a new triangle workflow
+- approve: Approve a human checkpoint
+- status: Show workflow status
+- list: List all workflows
+- cancel: Cancel a running workflow
+"""
+
+from __future__ import annotations
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+# Lazy import to avoid circular dependencies
+# These will be imported when the commands are actually run
+
+
+console = Console()
+
+
+def _get_persistence():
+    """Lazy import of TrianglePersistence."""
+    from agent_workshop.utils.persistence import TrianglePersistence
+    return TrianglePersistence()
+
+
+@click.group()
+def triangle() -> None:
+    """Triangle workflow commands.
+
+    Control human-gated automation workflows.
+    """
+
+
+@triangle.command()
+@click.option(
+    "--issue", "-i",
+    required=True,
+    type=int,
+    help="GitHub issue number to process",
+)
+@click.option(
+    "--repo", "-r",
+    required=True,
+    help="Repository in owner/repo format",
+)
+@click.option(
+    "--branch", "-b",
+    default=None,
+    help="Branch name (auto-generated if not provided)",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Show what would be done without executing",
+)
+def start(
+    issue: int,
+    repo: str,
+    branch: str | None,
+    dry_run: bool,
+) -> None:
+    """Start a new triangle workflow for an issue.
+
+    This creates a new workflow that will:
+    1. Parse the issue and generate code (IssueToPR)
+    2. Review the PR for security and quality (PRPipeline)
+    3. Apply fix suggestions from review (PRCommentProcessor)
+
+    Each stage has a human approval checkpoint.
+
+    Example:
+        triangle start --issue 42 --repo owner/repo
+    """
+    if branch is None:
+        branch = f"auto/triangle-v1/issue-{issue}"
+
+    if dry_run:
+        console.print("[yellow]DRY RUN[/yellow] - Would start triangle workflow:")
+        console.print(f"  Issue: #{issue}")
+        console.print(f"  Repo: {repo}")
+        console.print(f"  Branch: {branch}")
+        console.print(f"  Thread ID: issue-{issue}")
+        return
+
+    # TODO: Actually start the workflow when IssueToPR is implemented
+    console.print("[bold green]Starting triangle workflow[/bold green]")
+    console.print(f"  Issue: #{issue}")
+    console.print(f"  Repo: {repo}")
+    console.print(f"  Branch: {branch}")
+    console.print(f"  Thread ID: issue-{issue}")
+    console.print()
+    console.print("[yellow]Note:[/yellow] IssueToPR workflow not yet implemented.")
+    console.print("Workflow will be available in Phase 2.")
+
+
+@triangle.command()
+@click.argument("thread_id", required=False)
+@click.option(
+    "--step", "-s",
+    default=None,
+    help="Specific step to approve",
+)
+@click.option(
+    "--all", "-a", "approve_all",
+    is_flag=True,
+    help="Approve all pending checkpoints",
+)
+def approve(
+    thread_id: str | None,
+    step: str | None,
+    approve_all: bool,
+) -> None:
+    """Approve a human checkpoint to resume workflow.
+
+    This resumes a paused workflow that is waiting for human approval.
+    The workflow will continue from where it was paused.
+
+    Examples:
+        triangle approve issue-42
+        triangle approve issue-42 --step pr_review
+        triangle approve --all
+    """
+    persistence = _get_persistence()
+    pending = persistence.list_pending_approvals()
+
+    if not pending:
+        console.print("[green]No workflows waiting for approval.[/green]")
+        return
+
+    if approve_all:
+        console.print(f"[bold]Approving all {len(pending)} pending workflows...[/bold]")
+        for p in pending:
+            console.print(f"  ✓ Approved: {p.display_name} at {p.current_step}")
+            # TODO: Actually resume workflows when implemented
+        console.print()
+        console.print("[yellow]Note:[/yellow] Actual workflow resumption not yet implemented.")
+        return
+
+    if thread_id is None:
+        console.print("[red]Error:[/red] Please specify a thread_id or use --all")
+        console.print()
+        console.print("Pending workflows:")
+        for p in pending:
+            console.print(f"  • {p.thread_id} - {p.display_name} at {p.current_step}")
+        return
+
+    # Find the specific workflow
+    workflow = next((p for p in pending if p.thread_id == thread_id), None)
+    if workflow is None:
+        console.print(f"[red]Error:[/red] No pending workflow found with ID: {thread_id}")
+        return
+
+    if step and step != workflow.current_step:
+        console.print(
+            f"[red]Error:[/red] Workflow is at step '{workflow.current_step}', "
+            f"not '{step}'"
+        )
+        return
+
+    console.print(f"[bold green]Approved:[/bold green] {workflow.display_name}")
+    console.print(f"  Step: {workflow.current_step}")
+    console.print()
+    console.print("[yellow]Note:[/yellow] Actual workflow resumption not yet implemented.")
+
+
+@triangle.command()
+@click.argument("thread_id", required=False)
+@click.option(
+    "--verbose", "-v",
+    is_flag=True,
+    help="Show detailed information",
+)
+def status(
+    thread_id: str | None,
+    verbose: bool,
+) -> None:
+    """Show workflow status.
+
+    Without arguments, shows all active workflows.
+    With a thread_id, shows details for that specific workflow.
+
+    Examples:
+        triangle status
+        triangle status issue-42
+        triangle status --verbose
+    """
+    persistence = _get_persistence()
+
+    if thread_id:
+        # Show specific workflow
+        state = persistence.get_thread_state(thread_id)
+        if state is None:
+            console.print(f"[red]Error:[/red] No workflow found with ID: {thread_id}")
+            return
+
+        console.print(f"[bold]Workflow: {thread_id}[/bold]")
+        console.print()
+
+        if verbose:
+            for key, value in state.items():
+                console.print(f"  {key}: {value}")
+        else:
+            console.print(f"  Current step: {state.get('current_step', 'unknown')}")
+            console.print(f"  Requires approval: {state.get('requires_human_approval', False)}")
+            if state.get('error'):
+                console.print(f"  Error: {state.get('error')}")
+        return
+
+    # Show all workflows
+    pending = persistence.list_pending_approvals()
+    threads = persistence.list_threads()
+
+    console.print("[bold]Triangle Workflow Status[/bold]")
+    console.print()
+
+    if pending:
+        console.print(f"[yellow]Pending Approval ({len(pending)}):[/yellow]")
+        table = Table(show_header=True)
+        table.add_column("Thread ID", style="cyan")
+        table.add_column("Issue/Epic", style="green")
+        table.add_column("Current Step", style="yellow")
+
+        for p in pending:
+            table.add_row(p.thread_id, p.display_name, p.current_step)
+
+        console.print(table)
+        console.print()
+
+    if threads:
+        all_threads = set(threads)
+        pending_ids = {p.thread_id for p in pending}
+        active = all_threads - pending_ids
+
+        if active:
+            console.print(f"[green]Active ({len(active)}):[/green]")
+            for t in sorted(active):
+                console.print(f"  • {t}")
+            console.print()
+
+    if not pending and not threads:
+        console.print("[dim]No workflows found.[/dim]")
+
+
+@triangle.command("list")
+@click.option(
+    "--type", "-t", "workflow_type",
+    type=click.Choice(["issue", "epic", "all"]),
+    default="all",
+    help="Filter by workflow type",
+)
+def list_workflows(workflow_type: str) -> None:
+    """List all active and pending workflows.
+
+    Examples:
+        triangle list
+        triangle list --type issue
+        triangle list --type epic
+    """
+    persistence = _get_persistence()
+
+    filter_type = None if workflow_type == "all" else workflow_type
+    threads = persistence.list_threads(thread_type=filter_type)
+    pending = persistence.list_pending_approvals()
+    pending_ids = {p.thread_id for p in pending}
+
+    if not threads:
+        console.print("[dim]No workflows found.[/dim]")
+        return
+
+    table = Table(show_header=True, title="Triangle Workflows")
+    table.add_column("Thread ID", style="cyan")
+    table.add_column("Type", style="blue")
+    table.add_column("Status", style="green")
+
+    for thread_id in sorted(threads):
+        from agent_workshop.utils.persistence import parse_thread_id
+        parsed = parse_thread_id(thread_id)
+
+        if pending_ids and thread_id in pending_ids:
+            status_str = "[yellow]Pending Approval[/yellow]"
+        else:
+            status_str = "[green]Active[/green]"
+
+        table.add_row(thread_id, parsed["type"], status_str)
+
+    console.print(table)
+
+
+@triangle.command()
+@click.argument("thread_id")
+@click.option(
+    "--force", "-f",
+    is_flag=True,
+    help="Force cancel without confirmation",
+)
+def cancel(
+    thread_id: str,
+    force: bool,
+) -> None:
+    """Cancel a running workflow.
+
+    This stops a workflow and cleans up associated resources.
+    Use --force to skip confirmation.
+
+    Examples:
+        triangle cancel issue-42
+        triangle cancel issue-42 --force
+    """
+    persistence = _get_persistence()
+
+    state = persistence.get_thread_state(thread_id)
+    if state is None:
+        console.print(f"[red]Error:[/red] No workflow found with ID: {thread_id}")
+        return
+
+    if not force:
+        confirm = click.confirm(
+            f"Cancel workflow {thread_id}? This cannot be undone.",
+            default=False,
+        )
+        if not confirm:
+            console.print("[yellow]Cancelled.[/yellow]")
+            return
+
+    # TODO: Actually cancel the workflow when implemented
+    console.print(f"[bold red]Cancelled:[/bold red] {thread_id}")
+    console.print()
+    console.print("[yellow]Note:[/yellow] Workflow cancellation not yet fully implemented.")
+    console.print("The workflow state remains in the database for recovery.")

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,7 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "claude-code-sdk" },
+    { name = "click" },
     { name = "jinja2" },
     { name = "langfuse" },
     { name = "langgraph" },
@@ -16,6 +17,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
+    { name = "rich" },
     { name = "tiktoken" },
 ]
 
@@ -59,6 +61,7 @@ requires-dist = [
     { name = "claude-agent-sdk", marker = "extra == 'pipelines'", specifier = ">=0.1.0" },
     { name = "claude-agent-sdk", marker = "extra == 'validators'", specifier = ">=0.1.0" },
     { name = "claude-code-sdk", specifier = ">=0.0.25" },
+    { name = "click", specifier = ">=8.3.1" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "langfuse", specifier = ">=3.0.0" },
     { name = "langgraph", specifier = ">=0.2.0" },
@@ -74,6 +77,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'agents'", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'pipelines'", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'validators'", specifier = ">=6.0" },
+    { name = "rich", specifier = ">=14.2.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.0" },
     { name = "tiktoken", specifier = ">=0.7.0" },
 ]
@@ -862,6 +866,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321 },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -969,6 +985,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f7/25/4df633e7574254ada574822db2245bbee424725d1b01bccae10bf128794e/mcp-1.21.1.tar.gz", hash = "sha256:540e6ac4b12b085c43f14879fde04cbdb10148a09ea9492ff82d8c7ba651a302", size = 469071 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/af/01fb42df59ad15925ffc1e2e609adafddd3ac4572f606faae0dc8b55ba0c/mcp-1.21.1-py3-none-any.whl", hash = "sha256:dd35abe36d68530a8a1291daa25d50276d8731e545c0434d6e250a3700dd2a6d", size = 174852 },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
 ]
 
 [[package]]
@@ -1765,6 +1790,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481 },
+]
+
+[[package]]
+name = "rich"
+version = "14.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements CLI scaffolding for human-gated triangle workflows (#9):

### Commands

| Command | Purpose |
|---------|---------|
| `triangle start -i <num> -r <repo>` | Start workflow for GitHub issue |
| `triangle status [thread_id]` | Show workflow status |
| `triangle approve [thread_id]` | Resume paused workflow |
| `triangle list [--type]` | List all workflows |
| `triangle cancel <thread_id>` | Stop a running workflow |

### Features

- **Rich console output** with tables and colors
- **Dry-run mode** for start command (preview without executing)
- **Verbose mode** for status command (detailed state dump)
- **Integration with TrianglePersistence** for state queries

### Entry Point

Added to `pyproject.toml`:
```toml
[project.scripts]
triangle = "agent_workshop.cli.main:main"
```

After `uv sync` or `pip install`, the `triangle` command is available globally.

### Current State

CLI scaffolding is complete. Actual workflow execution is stubbed - Phase 2 `IssueToPR` integration will wire up real functionality.

## Test Plan

- [x] `triangle --help` shows all commands
- [x] `triangle start --help` shows options
- [x] `triangle status` runs without error
- [x] Ruff linting passes

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)